### PR TITLE
Final(?) Draft

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-issues-to-pdf",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Given a username, GIP will crawl through their repositories grabbing all issues and outputting them to a local folder as PDFs.",
   "main": "gip.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "phantom"
   ],
   "author": "Alex Valencia <alex.valencia@me.com> (http://www.avocadodesigns.net)",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/alexandervalencia/github-issues-to-pdf/issues"
   },


### PR DESCRIPTION
The project that was assigned was to create a program that would search through GitHub repositories and print out the issues as PDFs.

The parameters requested for the project were: 
- To be able to grab the issues from all repos or a specific few.
- To filter issues by year:
  - Issues that had been opened during that year (regardless of current open/closed status)
  - Issues that had been previously open before the start of the year and either remain open today or were closed in that year.
- To receive one letter sized pdf per issue.

As of testing on 4/19 - the program was achieving all set parameters with no issues.

**Improvements** that could be made: the render process is currently a bottleneck.

**Summary of problem:** For each repo, each issue gets processed one at a time taking roughly 3 sec a piece. Which makes makes a repo like alloy-editor with over 700 files take 35+ min to render each issue. It would be nice if there was some sort of a queue that would allow a limited number of issues to render at one time and wait for the queue to fill back up before running again.

HOWEVER, each _repo_ currently processes asynchronously. Which is why, if you select "all" it seems like a lot is happening at once at the start. Say an account has 20 repos, 20 phantomjs processes would all launch at the same time. But, if you multiplied that by 5 issues at a time, rather than 1, it would absolutely sink the CPU on most computers. But some repos have a small number of issues so at some point it's only processing 3 repos, 1 issue at a time, which is quite slow. 

I believe to implement some kind of queue system would take some major refactoring of my code.